### PR TITLE
Ci add redhat task

### DIFF
--- a/anchore-ci/release_tasks
+++ b/anchore-ci/release_tasks
@@ -143,3 +143,31 @@ push-prod-image-rebuild() {
         print_colorized ERROR "Production images can only be pushed in the CI environment."; echo
     fi
 }
+
+push-redhat-image() {
+    local GIT_TAG="${1:?'Missing required parameter: GIT_TAG'}"
+    local REDHAT_RELEASE="${2:-'r0'}"
+
+    # Test for required environment variables exported by CI system
+    if [[ "${CI:-false}" == true ]]; then
+        test "${PROD_IMAGE_REPO:?'Missing required environment variable: PROD_IMAGE_REPO'}"
+        test "${REDHAT_REGISTRY:?'Missing required environment variable: REDHAT_IMAGE'}"
+        test "${REDHAT_PASS:?'Missing required environment variable: REDHAT_PASS'}"
+
+        local prod_image="${PROD_IMAGE_REPO}:${GIT_TAG}"
+        local redhat_image="${REDHAT_REGISTRY}:${GIT_TAG}-${REDHAT_RELEASE}"
+
+        print_colorized WARN "Tagging and pushing production image to RedHat Connect."; echo
+        echo "${REDHAT_PASS}" | docker login -u unused --password-stdin scan.connect.redhat.com
+
+        print_colorized WARN "Pulling production image for RedHat release ${prod_image}."; echo
+        docker pull "${prod_image}"
+
+        print_colorized WARN "Tagging and pushing RedHat image ${redhat_image}."; echo
+        docker tag "${prod_image}" "${redhat_image}"
+        docker push "${redhat_image}"
+
+    else
+        print_colorized ERROR "RedHat images can only be pushed in the CI environment."; echo
+    fi
+}

--- a/anchore-ci/release_tasks
+++ b/anchore-ci/release_tasks
@@ -15,14 +15,13 @@ push-dev-image() {
     local latest_image="${DEV_IMAGE_REPO}:latest"
     local branch_image="${DEV_IMAGE_REPO}:${GIT_BRANCH}"
 
-    print_colorized INFO "Tagging and pushing dev image."; echo
-
     # Test for required environment variables exported by CI system
     if [[ "${CI:-false}" == true ]]; then
         test "${DOCKER_USER:?'Missing required env variable: DOCKER_USER'}"
         test "${DOCKER_PASS:?'Missing required env variable: DOCKER_PASS'}"
         test "${RELEASE_BRANCHES:?'Missing required env variable: RELEASE_BRANCHES'}"
 
+        print_colorized INFO "Preparing image ${dev_image} for push to DockerHub."; echo
         echo "${DOCKER_PASS}" | docker login -u "${DOCKER_USER}" --password-stdin
 
         print_colorized INFO "Tagging and pushing dev image ${dev_image}."; echo
@@ -39,7 +38,7 @@ push-dev-image() {
             docker push "${branch_image}"
         fi
     else
-        print_colorized INFO "Tagging and pushing image ${dev_image}."; echo
+        print_colorized INFO "Tagging and pushing image ${dev_image} using local credentials."; echo
         continue_prompt
         docker tag "${TEST_IMAGE_NAME}" "${dev_image}"
         docker push "${dev_image}"
@@ -53,16 +52,15 @@ push-rc-image() {
     local DEV_IMAGE_REPO="${2:?'Missing required parameter: DEV_IMAGE_REPO'}"
     local GIT_TAG="${3:?'Missing required parameter: GIT_TAG'}"
 
-    local dev_image="${DEV_IMAGE_REPO}:${COMMIT_SHA}"
-    local rc_image="${DEV_IMAGE_REPO}:${GIT_TAG}"
-
-    print_colorized WARN "Pushing RC image."; echo
-
     # Test for required environment variables exported by CI system
     if [[ "${CI:-false}" == true ]]; then
         test "${DOCKER_USER:?'Missing required environment variable: DOCKER_USER'}"
         test "${DOCKER_PASS:?'Missing required environment variable: DOCKER_PASS'}"
 
+        local dev_image="${DEV_IMAGE_REPO}:${COMMIT_SHA}"
+        local rc_image="${DEV_IMAGE_REPO}:${GIT_TAG}"
+
+        print_colorized WARN "Preparing image ${rc_image} for push to DockerHub."; echo
         echo "${DOCKER_PASS}" | docker login -u "${DOCKER_USER}" --password-stdin
 
         print_colorized INFO "Pulling dev image for release candidate: ${dev_image}."; echo
@@ -81,28 +79,26 @@ push-prod-image-release() {
     local GIT_BRANCH="${2:-'Missing required parameter: GIT_BRANCH'}"
     local GIT_TAG="${3:?'Missing required parameter: GIT_TAG'}"
 
-    print_colorized WARN "Tagging and pushing production image."; echo
-
-    local prod_image="${PROD_IMAGE_REPO}:${GIT_TAG}"
-    local rc_image="${DEV_IMAGE_REPO}:$(git describe --match "${GIT_TAG}-rc*" --tags --abbrev=0)"
-
-    # Test for required environment variables exported from CI system
+    # Test for required environment variables exported by CI system
     if [[ "${CI:-false}" == true ]]; then
         test "${DOCKER_USER:?'Missing required environment variable: DOCKER_USER'}"
         test "${DOCKER_PASS:?'Missing required environment variable: DOCKER_PASS'}"
         test "${LATEST_RELEASE_BRANCH:?'Missing required environment variable: LATEST_RELEASE_BRANCH'}"
         test "${PROD_IMAGE_REPO:?'Missing required environment variable: PROD_IMAGE_REPO'}"
 
+        local latest_tag_regex="^v${LATEST_RELEASE_BRANCH}\.[0-9]+\$"
+        local prod_image="${PROD_IMAGE_REPO}:${GIT_TAG}"
+        local rc_image="${DEV_IMAGE_REPO}:$(git describe --match "${GIT_TAG}-rc*" --tags --abbrev=0)"
+
+        print_colorized WARN "Preparing image ${prod_image} for push to DockerHub."; echo
         echo "${DOCKER_PASS}" | docker login -u "${DOCKER_USER}" --password-stdin
 
-        print_colorized WARN "Pulling RC image for release ${rc_image}."; echo
+        print_colorized WARN "Pulling RC image ${rc_image} for release."; echo
         docker pull "${rc_image}"
 
         print_colorized WARN "Tagging and pushing production image ${prod_image}."; echo
         docker tag "${rc_image}" "${prod_image}"
         docker push "${prod_image}"
-
-        local latest_tag_regex="^v${LATEST_RELEASE_BRANCH}\.[0-9]+\$"
 
         if [[ "${GIT_TAG}" =~ ${latest_tag_regex} ]]; then
             local latest_image="${PROD_IMAGE_REPO}:latest"
@@ -120,23 +116,22 @@ push-prod-image-rebuild() {
     local DEV_IMAGE_REPO="${2:?'Missing required parameter: DEV_IMAGE_REPO'}"
     local GIT_TAG="${3:?'Missing required parameter: GIT_TAG'}"
 
-    print_colorized WARN "Rebuilding image '${TEST_IMAGE_NAME}'."; echo
-
-    local dev_image="${DEV_IMAGE_REPO}:${COMMIT_SHA}"
-
-    # Test for required environment variables from CI system
+    # Test for required environment variables exported by CI system
     if [[ "${CI:-false}" == true ]]; then
         test "${DOCKER_USER:?'Missing required env variable: DOCKER_USER'}"
         test "${DOCKER_PASS:?'Missing required env variable: DOCKER_PASS'}"
         test "${PROD_IMAGE_REPO:?'Missing required environment variable: PROD_IMAGE_REPO'}"
 
+        local dev_image="${DEV_IMAGE_REPO}:${COMMIT_SHA}"
+        local rebuild_image="${PROD_IMAGE_REPO}:${GIT_TAG}"
+
+        print_colorized WARN "Preparing image ${rebuild_image} for push to DockerHub."; echo
         echo "${DOCKER_PASS}" | docker login -u "${DOCKER_USER}" --password-stdin
 
         print_colorized WARN "Pulling dev image for release candidate ${dev_image}."; echo
         docker pull "${dev_image}"
 
         print_colorized WARN "Tagging and pushing image ${rebuild_image}."; echo
-    		local rebuild_image="${PROD_IMAGE_REPO}:${GIT_TAG}"
         docker tag "${dev_image}" "${rebuild_image}"
         docker push "${rebuild_image}"
     else


### PR DESCRIPTION
Added a push-redhat-image task and did a little cleanup of the other functions to make them all use the same structure by moving all local variable declarations & print statements to happen after checking if the task is running in CI.