### PR TITLE
Adds Setup Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 .env*
 .venv
 .python-version
+.idea/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This repository provides an entry point and set of shared tasks for testing and CI.  It allows any provided task to be easily overridden.  Currently this is for use with Python.
 
+## Installation
+
+To install this library, use pip directly or add this to the requirements-test.txt file.
+
+```shell
+# Example install from pip
+python -m pip install git+https://github.com/anchore/test-infra.git@v0.0.1
+
+# Example of installing via pip and a requirements file
+# contents of requirements-test.txt
+git+https://github.com/anchore/test-infra.git@v0.0.1#egg=test-infra
+
+# install requirements via pip
+python -m pip install -r requirements-test.txt
+```
+
 ## Usage Example
 
 To use the provided task `clean`, clone this repo into your project's root directory, and create the following variables and targets in your makefile:
@@ -9,25 +25,15 @@ To use the provided task `clean`, clone this repo into your project's root direc
 ```
 TEST_IMAGE_NAME := my_image:latest
 TEST_HARNESS_REPO := https://github.com/anchore/test-infra.git
-CI_CMD := anchore-ci/ci_harness
+CI_CMD := ci_harness
 
-anchore-ci: ## Fetch test artifacts for the CI harness
-  rm -rf /tmp/test-infra; git clone $(TEST_HARNESS_REPO) /tmp/test-infra
-  mv ./anchore-ci ./anchore-ci-`date +%F-%H-%M-%S`; mv /tmp/test-infra/anchore-ci .
 
 .PHONY: clean
-clean: anchore-ci ## Clean up the project directory and delete dev image
+clean: ## Clean up the project directory and delete dev image
   @$(CI_CMD) clean $(TEST_IMAGE_NAME)
 ```
 
 To override the provided task with your own `clean`, provide an executable in `./scripts/ci/clean`, and the test harness entry point will invoke your task instead.
-
-Add the following to your .gitignore file so you don't pull in the test harness artifacts (unless you want to):
-
-```
-# CI scripts
-anchore-ci*/
-```
 
 The following tasks are provided (run `./anchore-ci/ci_harness` to see a current list in case this has changed):
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+import setuptools
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="test-infra",
+    version="0.0.1",
+    author="Anchore Inc.",
+    author_email="dev@anchore.com",
+    description="Anchore CI/Test Harness",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/anchore/test-infra",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+    scripts=[
+        'anchore-ci/ci_harness',
+        'anchore-ci/cli_driver.py',
+        'anchore-ci/cli_driver_config.py',
+        'anchore-ci/common_tasks',
+        'anchore-ci/release_tasks',
+        'anchore-ci/utils'
+    ],
+)


### PR DESCRIPTION
This project is currently used in a way where all consuming projects
must git clone this to a tmp directory and copy it to the local
directory.  With python this isn't necessary and we can provide
access to this project in a path by adding it into a project's
requirements-test.txt file.

This patch adds a setup.py file that will copy the ci_harness and
associated task files into the bin of the virtualenv.  With these
files on the path, they no longer require the complexity of make
target "anchore-ci:".  The documentation has been updated to provide
examples of installation and remove references to some of the make
usage no longer needed.

The process of using pip to manage the installation of this project
is served well by using releases/tags.  Because this project does
not change frequently, this is not a difficult or time consuming
process and takes just a moment in the github UI.

Signed-off-by: Ryan Brady <ryan.brady@anchore.com>